### PR TITLE
fixed south introspection

### DIFF
--- a/django_html_cleaner/models.py
+++ b/django_html_cleaner/models.py
@@ -67,21 +67,5 @@ class SanitizedTextField(models.TextField):
 
 if 'south' in settings.INSTALLED_APPS:
     from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([
-        (
-            [SanitizedCharField],
-            [],
-            {
-                "cleaner": ["cleaner", {}]
-            },
-        ),
-    ], ["^django_html_cleaner\.models\.SanitizedCharField"])
-    add_introspection_rules([
-        (
-            [SanitizedTextField],
-            [],
-            {
-                "cleaner": ["cleaner", {}]
-                    },
-            ),
-    ], ["^django_html_cleaner\.models\.SanitizedTextField"])
+    add_introspection_rules([], ["^django_html_cleaner\.models\.SanitizedCharField"])
+    add_introspection_rules([], ["^django_html_cleaner\.models\.SanitizedTextField"])


### PR DESCRIPTION
south can't handle python objects; so we have to ignore the cleaner object.
